### PR TITLE
Add .travis.yml to do builds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "googletest"]
 	path = googletest
-	url = git@github.com:abseil/googletest.git
+	url = https://github.com/abseil/googletest.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
 #matrix:
 
 before_install:
-echo "$TRAVIS_PULL_REQUEST"
+  - echo "$TRAVIS_PULL_REQUEST"
 
 install:
   # Install a supported cmake version (>= 3.10)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: cpp
+sudo: false
+
+branches:
+  only:
+    - master
+
+#matrix:
+
+#before_install:
+
+#install:
+
+script:
+  - mkdir build
+  - cd build
+  - cmake ..
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,20 @@ branches:
 
 #matrix:
 
-#before_install:
+before_install:
+echo "$TRAVIS_PULL_REQUEST"
 
-#install:
+install:
+  # Install a supported cmake version (>= 3.10)
+  - |
+    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      curl -o miniconda.sh  https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda install -y -c conda-forge cmake
 
 script:
   - mkdir build


### PR DESCRIPTION
This initial .travis.yml results in successful builds on Travis. Testing will need to be added after the gtest PR #12 comes in.

It was necessary to modify the .gitmodules to use https rather than ssh to resolve a permission denied error on Travis.

This may fix #3 or we may want to keep it open until tests are added.